### PR TITLE
Ask for email confirmation before validating a new user

### DIFF
--- a/database/prisma/schema.prisma
+++ b/database/prisma/schema.prisma
@@ -13,6 +13,7 @@ model User {
   name      String
   password  String
   createdAt DateTime  @default(now())
+  emailVerified Boolean @default(false)
   tokens    Token[]
   Webhook   Webhook[]
 }

--- a/server/package.json
+++ b/server/package.json
@@ -28,6 +28,7 @@
   "description": "",
   "dependencies": {
     "@prisma/client": "^4.9.0",
+    "@sendgrid/mail": "^7.7.0",
     "argon2": "^0.30.3",
     "body-parser": "^1.20.1",
     "csurf": "^1.11.0",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,7 +2,7 @@ import { Express } from 'express'
 import express from 'express'
 import { routes } from './routes';
 import { env } from './config/env';
-import bodyParser from 'body-parser';
+import bodyParser from 'body-parser';import { sendMail } from './utils/mailer';
 import csrf from 'csurf';
 import passport from 'passport';
 

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -4,3 +4,4 @@ import crypto from 'crypto';
 dotenv.config()
 export const env = process.env
 export const jwtSecret = crypto.randomBytes(32).toString('hex');
+export const mailSecret = crypto.randomBytes(32).toString('hex');

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -11,3 +11,4 @@ routes.get('/hook/', hook.GET);
 routes.post('/hook/:hook(*)', ..._.slice(hook.POST, 0, hook.POST.length - 1), hook.POST[hook.POST.length - 1]);
 routes.post('/auth/login', auth.login.POST);
 routes.get('/auth/logout', auth.logout.GET);
+routes.get('/auth/validate/:input_token', auth.validate_email.GET);

--- a/server/src/routes/auth/index.ts
+++ b/server/src/routes/auth/index.ts
@@ -3,8 +3,8 @@ import { logout } from "./logout";
 import { prisma } from "../../config/db";
 import passport from 'passport';
 import { Strategy as JWTStrategy, ExtractJwt } from 'passport-jwt';
-import { randomBytes } from 'crypto';
 import { jwtSecret } from "../../config/env";
+import { validate_email } from "./validate_email";
 
 let opts = {
     jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -27,5 +27,6 @@ passport.use(new JWTStrategy(opts, async (jwt_payload, done) => {
 
 export const auth = {
     login,
-    logout
+    logout,
+    validate_email
 };

--- a/server/src/routes/auth/login.ts
+++ b/server/src/routes/auth/login.ts
@@ -24,9 +24,10 @@ export const login = {
         if (userInput.error !== undefined)
             return res.status(400).json(userInput.error);
 
-        const user = await prisma.user.findUnique({
+        const user = await prisma.user.findFirst({
             where: {
-                email: userInput.value.email
+                email: userInput.value.email,
+                emailVerified: true
             }
         });
 
@@ -36,6 +37,7 @@ export const login = {
                     const prismaToken = await prisma.token.findFirst({
                         where: {
                             userId: user.id,
+                            valid: true,
                             type: 'API'
                         }
                     });

--- a/server/src/routes/auth/login.ts
+++ b/server/src/routes/auth/login.ts
@@ -43,7 +43,7 @@ export const login = {
                     });
                     if (prismaToken)
                         (user as any).token = jwt.sign({ token: prismaToken.id }, jwtSecret);
-                    res.status(200).json(user);
+                    res.status(200).json({"status": "ok", "user": _.omit(user, ['password'])});
                 } else {
                     res.status(401).json('Wrong password');
                 }

--- a/server/src/routes/auth/login.ts
+++ b/server/src/routes/auth/login.ts
@@ -2,18 +2,18 @@ import { Request, Response } from 'express';
 import { prisma } from '../../config/db';
 import Joi from 'joi';
 import jwt from 'jsonwebtoken';
-import { jwtSecret } from '../../config/env';
+import { jwtSecret, mailSecret } from '../../config/env';
 import * as argon2id from 'argon2';
+import { sendMail } from '../../utils/mailer';
 import _ from 'lodash';
 
 export const login = {
-
     GET: (req: Request, res: Response) => {
         res.status(200).send('ok');
     },
 
     POST: [
-        (req: Request, res: Response) => {
+        async (req: Request, res: Response) => {
         let userInputScheme = Joi.object(({
             email: Joi.string().email().required(),
             name: Joi.string().normalize().required(),
@@ -21,48 +21,57 @@ export const login = {
         }));
         let userInput = userInputScheme.validate(req.body);
 
-        console.log(userInput);
-        if (userInput.error !== undefined) {
-            return res.status(400).json(userInputScheme.validate(req.body).error);
-        }
-        prisma.user.findUnique({
+        if (userInput.error !== undefined)
+            return res.status(400).json(userInput.error);
+
+        const user = await prisma.user.findUnique({
             where: {
                 email: userInput.value.email
             }
-        })
-        .then(async (user) => {
-            if (user) {
-                try {
-                    if (await argon2id.verify(user.password, userInput.value.password)) {
-                        const prismaToken = await prisma.token.findFirst({
-                            where: {
-                                userId: user.id,
-                                type: 'API'
-                            }
-                        });
-                        if (prismaToken)
-                            _.merge(user, jwt.sign({ token: prismaToken }, jwtSecret));
-                        res.status(200).json(user);
-                    } else {
-                        res.status(401).json('Wrong password');
-                    }
-                } catch (err) {
-                    console.log(err);
-                    res.status(500).json('Internal server error');
+        });
+
+        if (user) {
+            try {
+                if (await argon2id.verify(user.password, userInput.value.password)) {
+                    const prismaToken = await prisma.token.findFirst({
+                        where: {
+                            userId: user.id,
+                            type: 'API'
+                        }
+                    });
+                    if (prismaToken)
+                        (user as any).token = jwt.sign({ token: prismaToken.id }, jwtSecret);
+                    res.status(200).json(user);
+                } else {
+                    res.status(401).json('Wrong password');
                 }
-            } else {
-                return prisma.user.create({
+            } catch (error) {
+                res.status(500).json(error);
+            }
+        } else {
+            try {
+                const password = await argon2id.hash(userInput.value.password);
+                const user = await prisma.user.create({
                     data: {
                         name: userInput.value.name,
                         email: userInput.value.email,
-                        password: await argon2id.hash(userInput.value.password)
+                        password: password
                     }
                 });
+                const prismaToken = await prisma.token.create({
+                    data: {
+                        type: 'API',
+                        user: {
+                            connect: { id: user.id }
+                        }
+                    }
+                });
+                (user as any).verification_token = jwt.sign({ token: prismaToken.id }, mailSecret);
+                sendMail(user.email, {token_id: (user as any).verification_token, type_of_action: 'an account verification'});
+                res.status(200).json(user);
+            } catch (error) {
+                res.status(500).json(error);
             }
-        })
-        .then((user) => {
-            res.status(200).json(user);
-            // TODO: send email with token
-        });
+        }
     }]
 };

--- a/server/src/routes/auth/validate_email.ts
+++ b/server/src/routes/auth/validate_email.ts
@@ -1,0 +1,62 @@
+import { Request, Response } from "express";
+import { prisma } from "../../config/db";
+import Joi from "joi";
+import jwt from "jsonwebtoken";
+import { TokenPayload } from "../../utils/token_type";
+import { mailSecret, jwtSecret } from "../../config/env";
+
+/**
+ * @api {post} /auth/validate_email/:input_token Validate email
+ */
+export const validate_email = {
+    GET: async (req: Request, res: Response) => {
+        let token_scheme = Joi.object({
+            input_token: Joi.string().required()
+        });
+
+        let parse = token_scheme.validate(req.params);
+        let parsed_token;
+
+        if (parse.error !== undefined){
+            return res.status(400).json(parse.error);
+        }
+        try {
+            parsed_token = jwt.verify(parse.value.input_token, mailSecret);
+        } catch (err) {
+            return res.status(401).json(err);
+        }
+        const user_id = await prisma.token.findFirst({
+            where: {
+                userId : (parsed_token as TokenPayload).userId,
+                type: 'EMAIL_VERIFICATION',
+            }
+        });
+        if (user_id) {
+            try {
+                await prisma.user.update({
+                    where: {
+                        id: user_id.userId
+                    },
+                    data: {
+                        emailVerified: true
+                    }
+                })
+                prisma.token.create({
+                    data: {
+                        userId: user_id.userId,
+                        type: 'API',
+                    }
+                });
+                prisma.token.delete({
+                    where: {
+                        id: user_id.id,
+                    }
+                });
+                const new_api_token = jwt.sign({ tokenId: user_id.userId }, jwtSecret);
+                return res.status(200).json({status: 'verified', api_token: new_api_token});
+            } catch (err) {
+                return res.status(500).json(err);
+            }
+        }
+    }
+}

--- a/server/src/utils/mailer.ts
+++ b/server/src/utils/mailer.ts
@@ -1,0 +1,22 @@
+import sgMail from '@sendgrid/mail';
+import { env, mailSecret } from '../config/env';
+
+
+sgMail.setApiKey(env.SEND_GRID_API_KEY || '');
+
+export const sendMail = async (to: string, template_data: Object) => {
+    const msg : sgMail.MailDataRequired = {
+        from: env.MAIL_FROM || '',
+        to,
+        templateId: 'd-833fed7671dd49418bec05fbb9d7e79e',
+        dynamicTemplateData: template_data,
+    };
+    try {
+        await sgMail.send(msg);
+    } catch  (error : any) {
+        console.log(error);
+        if (error.response) {
+            console.error(error.response.body);
+        }
+    }
+}

--- a/server/src/utils/token_type.ts
+++ b/server/src/utils/token_type.ts
@@ -1,0 +1,5 @@
+import { JwtPayload } from "jsonwebtoken";
+
+export interface TokenPayload extends JwtPayload {
+    userId: string;
+};

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -414,6 +414,29 @@
     tmp "0.2.1"
     ts-pattern "^4.0.1"
 
+"@sendgrid/client@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@sendgrid/client/-/client-7.7.0.tgz#f8f67abd604205a0d0b1af091b61517ef465fdbf"
+  integrity sha512-SxH+y8jeAQSnDavrTD0uGDXYIIkFylCo+eDofVmZLQ0f862nnqbC3Vd1ej6b7Le7lboyzQF6F7Fodv02rYspuA==
+  dependencies:
+    "@sendgrid/helpers" "^7.7.0"
+    axios "^0.26.0"
+
+"@sendgrid/helpers@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@sendgrid/helpers/-/helpers-7.7.0.tgz#93fb4b6e2f0dc65080440d6a784cc93e8e148757"
+  integrity sha512-3AsAxfN3GDBcXoZ/y1mzAAbKzTtUZ5+ZrHOmWQ279AuaFXUNCh9bPnRpN504bgveTqoW+11IzPg3I0WVgDINpw==
+  dependencies:
+    deepmerge "^4.2.2"
+
+"@sendgrid/mail@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@sendgrid/mail/-/mail-7.7.0.tgz#aba09f5ce2e9d8ceee92284c3ea8b4a90b0e38fe"
+  integrity sha512-5+nApPE9wINBvHSUxwOxkkQqM/IAAaBYoP9hw7WwgDNQPxraruVqHizeTitVtKGiqWCKm2mnjh4XGN3fvFLqaw==
+  dependencies:
+    "@sendgrid/client" "^7.7.0"
+    "@sendgrid/helpers" "^7.7.0"
+
 "@sideway/address@^4.1.3":
   version "4.1.4"
   resolved "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz"
@@ -792,6 +815,13 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+axios@^0.26.0:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+  dependencies:
+    follow-redirects "^1.14.8"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -1182,6 +1212,11 @@ decamelize@^1.1.0, decamelize@^1.2.0:
   resolved "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 defaults@^1.0.3:
   version "1.0.4"
   resolved "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz"
@@ -1458,6 +1493,11 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+follow-redirects@^1.14.8:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 form-data@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
# Why ? 

Creating a user without verify if it's a real humain being leaves the door open to bot accounts.
This PR aims to fix this problem by adding email verification in the authentication process.

## Authentication process as of now

### 1. User sends a POST request to `/login` with JSON payload
```json
{"email":"wexal32023@minterp.com","name":"john","password": "azer"}
```

#### 1.1 User is already known by the system AND is validated

If provided with the correct email/password combo, the route will send back the api token of the user with "ok" as the status
(This token shall then be transfered to the user by the frontend in the `Authorization: Bearer` header, cc @majent4)


#### 1.2 User is loggin in for the first time

An email is sent via sendgrid to the email address provided in the json payload.
The user is required to validate their account, the webclient shall the redirect the request to `/auth/validate_email/:input_token` cc @majent4

# TODO

- [ ] Delete un-verified users from db with a cron job
- [ ] Integrate OAuth data to the login process


### Commit history
***

- db: Add verified field to user
- env: Create separate mail secret
- auth: Ask for email validation
