### PR TITLE
back: Added mutation and query for oAuth classes, added JSON to yarn and package

### DIFF
--- a/database/package.json
+++ b/database/package.json
@@ -37,6 +37,7 @@
     "dotenv-cli": "^6.0.0",
     "graphql": "^16.6.0",
     "graphql-scalars": "^1.20.1",
+    "graphql-type-json": "^0.3.2",
     "typescript": "^4.9.4"
   },
   "prisma": {

--- a/database/src/schemas/index.ts
+++ b/database/src/schemas/index.ts
@@ -48,10 +48,10 @@ scalar JSONObject
 
     type oAuthUserData {
         user: User!
-        data: JSONObject!
+        data: JSONObject
         oAuthProvider: oAuthProvider!
-        accessToken: String!
-        refreshToken: String!
+        accessToken: String
+        refreshToken: String
     }
 
     type Query {
@@ -73,7 +73,7 @@ scalar JSONObject
         createUser(name: String!, email: String!, password: String!): Int!
         createService(name: String!): Int!
         createChainedReaction(actionId: Int!, serviceName: String!, actionName: String!, outgoingWebhook: String!): Int!
-        createOAuthUserData(userId: String!, refreshToken: String!, accessToken: String!, data: JSONObject!, oAuthProviderName: String!, providerUserId: String!): Int!
+        createOAuthUserData(userId: String!, refreshToken: String, accessToken: String, data: JSONObject, oAuthProviderName: String!, providerUserId: String!): Int!
     }
 
     scalar DateTime
@@ -152,22 +152,22 @@ export const resolvers = {
             if (args.userId === undefined || args.userId === '') {
                 return 400
             }
-            if (args.refreshToken === undefined || args.refreshToken === '') {
+            if (args.oAuthProviderName === undefined || args.oAuthProviderName === '') {
                 return 400
             }
-            if (args.accessToken === undefined || args.accessToken === '') {
+            if (args.providerUserId === undefined || args.providerUserId === '') {
                 return 400
             }
-            if (args.data === undefined || args.data === '') {
-                return 400
-            }
+            const accToken = args.accessToken === undefined ? '' : args.accessToken
+            const refToken = args.refreshToken === undefined ? '' : args.refreshToken
+            const myData = args.data === undefined ? {} : args.data
             await context.prisma.oAuthUserData.create({
                 data: {
                     userId: args.userId,
-                    refreshToken: args.refreshToken,
+                    refreshToken: refToken,
                     providerUserId: args.providerUserId,
-                    accessToken: args.accessToken,
-                    data: args.data,
+                    accessToken: accToken,
+                    data: myData,
                     oAuthProviderName: args.oAuthProviderName
                 }
             });

--- a/database/yarn.lock
+++ b/database/yarn.lock
@@ -1596,6 +1596,11 @@ graphql-tag@^2.11.0:
   dependencies:
     tslib "^2.1.0"
 
+graphql-type-json@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/graphql-type-json/-/graphql-type-json-0.3.2.tgz#f53a851dbfe07bd1c8157d24150064baab41e115"
+  integrity sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==
+
 graphql@*, graphql@^16.6.0:
   version "16.6.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"


### PR DESCRIPTION
Quick PR that allows graphQL to handle incoming mutations to create oAuthUserData class in db, you must give the following arguments :
- userId (as a String)
- refreshToken (as a String)
- accessToken (as a String)
- data (as a JSONObject)
- providerUserId (as a String)
- oAuthProviderName (as a String)

Mutation sends back 200 if it works